### PR TITLE
Fixed issue with getting distinct list of people

### DIFF
--- a/PeopleLocationApi/Models/User.cs
+++ b/PeopleLocationApi/Models/User.cs
@@ -7,7 +7,7 @@
         public string IpAddress { get; private set; }
 
         public static User Create(long id, string firstName, string lastName, string email, double latitude,
-            double  longitude, string ipAddress)
+            double longitude, string ipAddress)
         {
             return new User
             {

--- a/PeopleLocationApi/Services/BpdtsTestAppService.cs
+++ b/PeopleLocationApi/Services/BpdtsTestAppService.cs
@@ -11,7 +11,10 @@ namespace PeopleLocationApi.Services
         Task<IEnumerable<Person>> GetPeopleLivingIn(string city);
         Task<List<User>> GetUsers();
     }
-
+    /// <summary>
+    /// This service encapsulates the calls the bpdts test app endpoints using a httpClient
+    /// and returns the deserialised response as lists of People (or its sub type Users)
+    /// </summary>
     public class BpdtsTestAppService : IBpdtsTestAppService
     {
         private readonly HttpClient _httpClient;

--- a/PeopleLocationApi/Tasks/PeopleLocationTask.cs
+++ b/PeopleLocationApi/Tasks/PeopleLocationTask.cs
@@ -13,7 +13,11 @@ namespace PeopleLocationApi.Tasks
         Task<IEnumerable<Person>> GetPeopleCoordinatesWithIn(string city, double miles);
         Task<IEnumerable<Person>> GetPeopleLivingInOrCoordinatesWithInFiftyMiles(string london, double miles);
     }
-
+    /// <summary>
+    /// The purpose of this class is to coordinate the interaction of the client
+    /// with the business functionality of getting users form the bpdts test app
+    /// and returning filtered people. 
+    /// </summary>
     public class PeopleLocationTask : IPeopleLocationTask
     {
         private readonly IBpdtsTestAppService _bpdtsTestAppService;
@@ -37,9 +41,18 @@ namespace PeopleLocationApi.Tasks
         public async Task<IEnumerable<Person>> GetPeopleLivingInOrCoordinatesWithInFiftyMiles(string city, double miles)
         {
             List<Person> peopleLivingIn = (List<Person>) await GetPeopleLivingIn(city);
-            var peopleWithin = await GetPeopleCoordinatesWithIn(city, miles);
-            var people = peopleLivingIn.Union(peopleWithin).ToList();
-            return people;
+            var usersWithin =  await GetPeopleCoordinatesWithIn(city, miles);
+
+            //Concat the two lists then do a groupby on id to get a distinct list of people.
+            //A union will not work as users are a sub type of people, the extra properties
+            //on user will mean the same person will be treated as different person on the join.
+            var people = peopleLivingIn.Concat(usersWithin);
+
+            var distinctPeople = people.GroupBy(x => x.Id)
+                .Select(g => g.First())
+                .ToList();
+
+            return distinctPeople;
         }
 
         private static List<Person> FilterWithIn(List<User> users, double miles)

--- a/PeopleLocationApiTests/Tasks/PeopleLocationTaskTests.cs
+++ b/PeopleLocationApiTests/Tasks/PeopleLocationTaskTests.cs
@@ -49,5 +49,28 @@ namespace PeopleLocationApiTests.Tasks
             result.ShouldNotBeNull();
             result.Count().ShouldBe(people.Count);
         }
+
+        [Fact]
+        public async void UsersEitherLivingInOrWithinFiftyMilesLondonShouldReturnDistinctPeople()
+        {
+            // Arrange
+            const double miles = 50;
+            var users = PeopleTestData.GetUsers();
+            var people = PeopleTestData.GetPeople();
+            var expectedCount = 1;// Cause first person in users and people are the same
+            var mock = new Mock<IBpdtsTestAppService>();
+            mock.Setup(x => x.GetUsers()).ReturnsAsync(users).Verifiable();
+            mock.Setup(x => x.GetPeopleLivingIn(LondonCityConstants.Name)).ReturnsAsync(people).Verifiable();
+            var sut = new PeopleLocationTask(mock.Object);
+
+            //Act
+            var result = await sut.GetPeopleLivingInOrCoordinatesWithInFiftyMiles(LondonCityConstants.Name, miles);
+
+            //Assert
+            mock.Verify(x => x.GetUsers(), Times.Once);
+            mock.Verify(x => x.GetPeopleLivingIn(LondonCityConstants.Name), Times.Once);
+            result.ShouldNotBeNull();
+            result.Count().ShouldBe(expectedCount);
+        }
     }
 }


### PR DESCRIPTION
Fixed issue with logic in GetPeopleLivingInOrCoordinatesWithInFiftyMiles which was not returning a distinct list of people.
Test GetPeopleLivingInOrCoordinatesWithInFiftyMiles to ensure it returns as distinct list.